### PR TITLE
Remove SQLite JDBC reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Please install the following dependencies before you can use PWAM:
 
 * [Fabric API](https://modrinth.com/mod/fabric-api)
 * [Fabric Language Kotlin](https://modrinth.com/mod/fabric-language-kotlin)
-* [SQLite JDBC](https://modrinth.com/plugin/sqlite-jdbc)
 
 ## How to use it?
 


### PR DESCRIPTION
Unfortunately, this mod's metadata isn't updated regularly to be up-to-date with recent Minecraft versions.

We're now including JDBC library directly into all distributions since dab6357393e3135a6c1ac4916c5a9878843bf7de