### PR TITLE
Use version-aware Adventure json serializer

### DIFF
--- a/fabric/1.18.2/src/main/kotlin/com/turikhay/mc/pwam/fabric/PWAM.kt
+++ b/fabric/1.18.2/src/main/kotlin/com/turikhay/mc/pwam/fabric/PWAM.kt
@@ -5,6 +5,7 @@ import com.turikhay.mc.pwam.common.initDb
 import com.turikhay.mc.pwam.fabric.common.FabricAskServerSuggestion
 import com.turikhay.mc.pwam.fabric.common.FabricCommandNodeAccessor
 import com.turikhay.mc.pwam.fabric.platform.SUPPORTS_EMOJI
+import com.turikhay.mc.pwam.fabric.platform.adventureJsonVersion
 import com.turikhay.mc.pwam.fabric.platform.deserializeComponent
 import com.turikhay.mc.pwam.mc.IClient
 import com.turikhay.mc.pwam.mc.Session
@@ -14,7 +15,9 @@ import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents
 import net.fabricmc.loader.api.FabricLoader
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
+import net.kyori.adventure.text.serializer.json.JSONOptions
 import net.kyori.adventure.translation.GlobalTranslator
+import net.minecraft.SharedConstants
 import net.minecraft.client.MinecraftClient
 import net.minecraft.util.Util
 import org.jetbrains.exposed.sql.Database
@@ -70,10 +73,19 @@ private object Client : IClient {
             command,
         )
 
+    val gsonSerializer: GsonComponentSerializer by lazy {
+        GsonComponentSerializer.builder()
+            .options(
+                JSONOptions.byDataVersion()
+                    .at(adventureJsonVersion())
+            )
+            .build()
+    }
+
     override fun sendMessage(text: Component) {
         client().inGameHud.chatHud.addMessage(
             deserializeComponent(
-                GsonComponentSerializer.gson().serializeToTree(
+                gsonSerializer.serializeToTree(
                     GlobalTranslator.render(text, Locale.getDefault())
                 )
             )

--- a/fabric/1.18.2/src/main/kotlin/com/turikhay/mc/pwam/fabric/platform/AdventureJsonVersion.kt
+++ b/fabric/1.18.2/src/main/kotlin/com/turikhay/mc/pwam/fabric/platform/AdventureJsonVersion.kt
@@ -1,0 +1,6 @@
+package com.turikhay.mc.pwam.fabric.platform
+
+// See net.kyori.adventure.text.serializer.json.JSONOptions
+fun adventureJsonVersion(): Int {
+    return 2526 // VERSION_1_16 = 2526; // 20w16a
+}

--- a/fabric/1.19.4/src/main/kotlin/com/turikhay/mc/pwam/fabric/platform/AdventureJsonVersion.kt
+++ b/fabric/1.19.4/src/main/kotlin/com/turikhay/mc/pwam/fabric/platform/AdventureJsonVersion.kt
@@ -1,0 +1,1 @@
+../../../../../../../../../../1.18.2/src/main/kotlin/com/turikhay/mc/pwam/fabric/platform/AdventureJsonVersion.kt

--- a/fabric/1.19.4/src/main/kotlin/com/turikhay/mc/pwam/fabric/platform/AdventureVersion.kt
+++ b/fabric/1.19.4/src/main/kotlin/com/turikhay/mc/pwam/fabric/platform/AdventureVersion.kt
@@ -1,1 +1,0 @@
-../../../../../../../../../../1.18.2/src/main/kotlin/com/turikhay/mc/pwam/fabric/platform/AdventureVersion.kt

--- a/fabric/1.19.4/src/main/kotlin/com/turikhay/mc/pwam/fabric/platform/AdventureVersion.kt
+++ b/fabric/1.19.4/src/main/kotlin/com/turikhay/mc/pwam/fabric/platform/AdventureVersion.kt
@@ -1,0 +1,1 @@
+../../../../../../../../../../1.18.2/src/main/kotlin/com/turikhay/mc/pwam/fabric/platform/AdventureVersion.kt

--- a/fabric/1.20.4/src/main/kotlin/com/turikhay/mc/pwam/fabric/platform/AdventureJsonVersion.kt
+++ b/fabric/1.20.4/src/main/kotlin/com/turikhay/mc/pwam/fabric/platform/AdventureJsonVersion.kt
@@ -1,0 +1,10 @@
+package com.turikhay.mc.pwam.fabric.platform
+
+import net.minecraft.SharedConstants
+
+fun adventureJsonVersion(): Int {
+    if (SharedConstants.getProtocolVersion() < 765) { // < 1.20.3
+        return 2526
+    }
+    return 3679
+}

--- a/fabric/1.20.6/src/main/kotlin/com/turikhay/mc/pwam/fabric/platform/AdventureJsonVersion.kt
+++ b/fabric/1.20.6/src/main/kotlin/com/turikhay/mc/pwam/fabric/platform/AdventureJsonVersion.kt
@@ -1,0 +1,10 @@
+package com.turikhay.mc.pwam.fabric.platform
+
+import net.minecraft.SharedConstants
+
+fun adventureJsonVersion(): Int {
+    if (SharedConstants.getProtocolVersion() < 769) { // < 1.21.4
+        return 3819
+    }
+    return 4174
+}


### PR DESCRIPTION
Recently, Mojang has been changing chat formatting rather often. Recent versions of Adventure aim to be compatible with these changes.

At the time of writing, there is no support for 1.21.5 (see #17)